### PR TITLE
Fix for Angular update error

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	"peerDependencies": {
 		"@angular/common": ">= 13.0.0 < 14.0.0",
 		"@angular/core": ">= 13.0.0 < 14.0.0",
-		"rxjs": ">= 6.0.0 < 7.0.0"
+		"rxjs": ">= 6.0.0 < 8.0.0"
 	},
 	"devDependencies": {
 		"@angular-builders/jest": "~13.0.3",


### PR DESCRIPTION
`$ npx @angular/cli@13 update @angular/core@13 @angular/cli@13`
...
```
Package "@itzrabbs/angular-notifier" has an incompatible peer dependency to "rxjs" (requires ">= 6.0.0 < 7.0.0", would install "7.5.4").
✖ Migration failed: Incompatible peer dependencies found.
Peer dependency warnings when installing dependencies means that those dependencies might not work correctly together.
You can use the '--force' option to ignore incompatible peer dependencies and instead address these warnings later.
  See "/private/var/folders/21/hdp3gdt97lj9y60w5by576vc0000gn/T/ng-00XqZ5/angular-errors.log" for further details.
```